### PR TITLE
Updated get_base_path() to be less presumptive

### DIFF
--- a/post-formats.php
+++ b/post-formats.php
@@ -29,7 +29,7 @@ class PostFormats{
 
     $parts = explode(get_template(), dirname(__FILE__));
 
-    $url = str_replace('\\', '/', $base . $parts[1]);
+    $url = str_replace('\\', '/', $base . array_pop($parts) );
 
     return $url;
   }


### PR DESCRIPTION
if  my theme is named "example-theme" and my website is served from a folder with the same name, then get_base_path is broken because it assumed the path to the assets (js/css) would be in the wrong location in the exploded array.

For instance:
/var/www/example-theme/wp-content/themes/example-theme/vendor/arcath/post-formats/post-formats.js
the old code would be wrong because the exploded path would be:

[0] => /srv/www/
[1] => /htdocs/wp-content/themes/
[2] => /vendor/arcath/post-formats

array_pop() solves this issues.